### PR TITLE
feat: 헤더 드랍다운 추가

### DIFF
--- a/src/components/ExploreWineButton.tsx
+++ b/src/components/ExploreWineButton.tsx
@@ -1,7 +1,7 @@
-'use client'
-import Link from "next/link";
-import React from "react";
-import { motion } from "framer-motion";
+'use client';
+import Link from 'next/link';
+import React from 'react';
+import { motion } from 'framer-motion';
 
 const ExploreWineButton = () => {
   return (
@@ -13,7 +13,7 @@ const ExploreWineButton = () => {
     >
       <Link
         href="/wines"
-        className="bg-[#6A42DB] w-[280px] h-[50px] rounded-full mt-[104px] flex flex-row items-center justify-center text-[16px] font-bold text-[white]"
+        className="bg-garnet w-[280px] h-[50px] rounded-full mt-[104px] flex flex-row items-center justify-center text-[16px] font-bold text-[white]"
       >
         와인 보러가기
       </Link>

--- a/src/components/common/DropdownItems.tsx
+++ b/src/components/common/DropdownItems.tsx
@@ -1,0 +1,27 @@
+interface DropdownProps {
+  isOpen: boolean;
+  labels: string[];
+  actions: Record<string, () => void>;
+}
+
+function DropdownItems({ isOpen, labels, actions }: DropdownProps) {
+  return (
+    <>
+      {isOpen && (
+        <ul className="absolute right-0 flex flex-col mt-2 bg-white border border-gray-300 rounded-2xl z-10">
+          {labels.map((label) => (
+            <li
+              key={label}
+              className="m-[6px] px-4 py-2 bg-white rounded-2xl hover:bg-[#F3E7E6] hover:text-garnet cursor-pointer whitespace-nowrap text-center"
+              onClick={actions[label]}
+            >
+              {label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}
+
+export default DropdownItems;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,10 +4,16 @@ import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import images from '../../../public/images/images';
 import { useAuthStore } from '@/store/authStore';
+import DropdownItems from './DropdownItems';
+import { useRouter } from 'next/navigation';
+
+const labels: string[] = ['마이페이지', '로그아웃'];
 
 const Header = () => {
   const { user, logout, getMe, isAuthenticated } = useAuthStore();
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const router = useRouter();
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -28,8 +34,20 @@ const Header = () => {
     fetchUserData();
   }, [getMe, isAuthenticated]); // isAuthenticated가 변경될 때마다 사용자 정보 갱신
 
-  const handleLogout = (): void => {
-    logout();
+  const handleDropdownOpen = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const actions = {
+    마이페이지: () => {
+      handleDropdownOpen();
+      router.push('/myprofile');
+    },
+
+    로그아웃: () => {
+      handleDropdownOpen();
+      logout();
+    },
   };
 
   return (
@@ -47,17 +65,21 @@ const Header = () => {
       {isLoading ? (
         <div className="w-[40px] h-[40px] max-md:w-5 max-md:h-5 bg-gray-700 rounded-full animate-pulse" />
       ) : user ? (
-        <div className="rounded-full border-2">
-          <div className="relative flex items-center rounded-full w-[40px] h-[40px] max-md:w-6 max-md:h-6 cursor-pointer overflow-hidden">
-            <Image
-              className="w-auto h-auto"
-              src={user.image || images.defaultProfile}
-              alt="user"
-              objectFit="cover"
-              fill
-              sizes="40"
-            />
+        <div className="relative">
+          <div className="rounded-full border-2">
+            <div className="relative flex items-center rounded-full w-[40px] h-[40px] max-md:w-6 max-md:h-6 cursor-pointer overflow-hidden">
+              <Image
+                className="w-auto h-auto"
+                src={user.image || images.defaultProfile}
+                alt="user"
+                objectFit="cover"
+                fill
+                sizes="40"
+                onClick={handleDropdownOpen}
+              />
+            </div>
           </div>
+          <DropdownItems isOpen={isOpen} labels={labels} actions={actions} />
         </div>
       ) : (
         <div className="flex items-center">

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -7,6 +7,7 @@ import {
   handleKakaoCallbackRequest,
   fetchUser,
 } from '@/services/auth'; // 분리된 API 함수 import
+import { navigate } from '@/utils/navigate';
 
 interface User {
   id: number;
@@ -92,6 +93,8 @@ export const useAuthStore = create<AuthState>()(
           accessToken: null,
           refreshToken: null,
         });
+        // 로그아웃 시 랜딩페이지로 이동
+        navigate('/');
       },
 
       // accessToken 재발급

--- a/src/utils/navigate.ts
+++ b/src/utils/navigate.ts
@@ -1,0 +1,5 @@
+export const navigate = (path: string) => {
+  if (typeof window !== 'undefined') {
+    window.location.href = path;
+  }
+};


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요 -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- DropdownItems 공통 컴포넌트 구현
- 헤더 프로필을 누르면 드랍 다운이 표시됩니다
- 마이페이지를 누르면 마이페이지로 이동
- 로그아웃을 누르면 유저 로그아웃이 되며 랜딩페이지로 이동
- 로그아웃 함수 기능에 페이지 이동을 추가하여 이제 로그아웃 함수만 호출 하면 랜딩 페이지로 이동됩니다

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![스크린샷 2025-05-01 191046](https://github.com/user-attachments/assets/461f2a75-52ef-4639-b67a-1438f6504708)


## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1. 로그인을 합니다
2. 프로필 이미지를 클릭 합니다
3. 클릭 시 드랍다운이 표시됩니다
4. 마이페이지 클릭 시 마이페이지로 이동, 로그아웃 클릭 시 로그아웃

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->
#49 헤더 드랍다운 및 로그아웃시 페이지 리다이렉트

## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->
DropdownSelect도 쓰이는데 따로 DropdownItems을 쓰는 코드도 많아 공통으로 만들었습니다.
```
// 사용 예시
const [isOpen, setIsOpen] = useState<boolean>(false);
const labels: string[] = ['마이페이지', '로그아웃'];
const actions = {
  마이페이지: () => {
    handleDropdownOpen();
    router.push('/myprofile');
  },

  로그아웃: () => {
    handleDropdownOpen();
    logout();
  },
};
<DropdownItems isOpen={isOpen} labels={labels} actions={actions} />
```
